### PR TITLE
Updated subPathForResource to no longer require an objectID

### DIFF
--- a/RESTMan/RESTMan.m
+++ b/RESTMan/RESTMan.m
@@ -385,7 +385,7 @@
     NSString *root = [self stringForResource:type];
     if (!objectID) {
         DLog(@"Missing root object id for %@", root);
-        return @"";
+        return root;
     } else {
         return [root stringByAppendingPathComponent:objectID];
     }


### PR DESCRIPTION
I often do not require ids for update operations because that is handled via my authentication.